### PR TITLE
✨ Auto-Heal Socket Close

### DIFF
--- a/lib/src/network/socket_transport.dart
+++ b/lib/src/network/socket_transport.dart
@@ -45,8 +45,12 @@ class SocketTransport {
     // Listen for messages
     channel?.stream.listen(_socketReceive, onError: (error) {
       _connected = false;
+      // auto-heal by re-opening
+      this.open();
     }, onDone: () {
       _connected = false;
+      // auto-heal by re-opening
+      this.open();
     });
   }
 


### PR DESCRIPTION
### Problem Statement

Socket gets closed silently by normal events (i.e. app to background). See  #8 for more description.

### Fix

Listen to `onError` and `onDone` events and re-open the connection when those events are fired.