### PR TITLE
🛠 Fixed incorrect working of signTypeData method

### DIFF
--- a/lib/src/providers/ethereum_walletconnect_provider.dart
+++ b/lib/src/providers/ethereum_walletconnect_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:convert/convert.dart';
@@ -41,9 +42,11 @@ class EthereumWalletConnectProvider extends WalletConnectProvider {
     required String address,
     required Map<String, dynamic> typedData,
   }) async {
+    final encodedTypedData = jsonEncode(typedData);
+
     final result = await connector.sendCustomRequest(
       method: 'eth_signTypedData',
-      params: [address, typedData],
+      params: [address, encodedTypedData],
     );
 
     return result;


### PR DESCRIPTION
Problem was connected with https://github.com/RootSoft/walletconnect-dart-sdk/issues/20
As I understood, JSON incorrectly encoded and then, cannot be open, for example, in MetaMask wallet. I guess, that in other wallets if u use this methods it will work the same.
But when typedData will be stringified, it works as it should.
If my theory is not correct, write the real reason, it is interesting for me.