### PR TITLE
Various fixes mainly for wallet side of walletconnect

### DIFF
--- a/example/wallet/.vscode/launch.json
+++ b/example/wallet/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "wallet",
+            "request": "launch",
+            "type": "dart"
+        }
+    ]
+}

--- a/lib/src/walletconnect.dart
+++ b/lib/src/walletconnect.dart
@@ -472,6 +472,10 @@ class WalletConnect {
     if (session.handshakeTopic.isNotEmpty) {
       transport.subscribe(topic: session.handshakeTopic);
     }
+
+    if (session.peerId.isNotEmpty) {
+      transport.subscribe(topic: session.peerId);
+    }
   }
 
   /// Handles incoming JSON RPC requests that do not have a mapped id.


### PR DESCRIPTION
@RootSoft - there are some issue I've discovered while trying to implement wallet side of WalletConnect:

- `PeerId` and `PeerMeta` correctly returned in `approveSession` (otherwise dApp will ignore the response)
- `PeerId` is added to subscriptions when the session approved
- Initialization of transport and subscriptions moved to `createSession` so a new session can be created using the same connector after the old one is killed
- In `killSession` sending requests is awaited before transport is closed (otherwise transport is closed before the request is sent)