### PR TITLE
Fixes for wallets

### DIFF
--- a/lib/src/walletconnect.dart
+++ b/lib/src/walletconnect.dart
@@ -83,6 +83,10 @@ class WalletConnect {
     if (session.handshakeTopic.isNotEmpty) {
       transport.subscribe(topic: session.handshakeTopic);
     }
+
+    if (session.peerId.isNotEmpty) {
+      transport.subscribe(topic: session.peerId);
+    }
   }
 
   /// WalletConnect is an open source protocol for connecting decentralised
@@ -218,14 +222,18 @@ class WalletConnect {
       throw WalletConnectException('Session currently connected');
     }
 
+    if (session.peerId.isNotEmpty) {
+      _transport.subscribe(topic: session.peerId);
+    }
+
     final params = {
       'approved': true,
       'chainId': chainId,
       'networkId': 0,
       'accounts': accounts,
       'rpcUrl': '',
-      'peerId': session.clientId,
-      'peerMeta': session.clientMeta,
+      'peerId': session.peerId,
+      'peerMeta': session.peerMeta,
     };
 
     final response = JsonRpcResponse(
@@ -385,7 +393,11 @@ class WalletConnect {
   }
 
   void _handleIncomingMessages(WebSocketMessage message) async {
-    final activeTopics = [session.clientId, session.handshakeTopic];
+    final activeTopics = [
+      session.clientId,
+      session.handshakeTopic,
+      session.peerId,
+    ];
     if (!activeTopics.contains(message.topic)) {
       return;
     }

--- a/lib/src/walletconnect.dart
+++ b/lib/src/walletconnect.dart
@@ -325,6 +325,21 @@ class WalletConnect {
     return _sendRequest(request);
   }
 
+  /// Send a custom response.
+  Future sendCustomResponse({
+    required int id,
+    String? result,
+    String? error,
+  }) async {
+    final response = JsonRpcResponse(
+      id: id,
+      result: result,
+      error: error,
+    );
+
+    return _sendResponse(response);
+  }
+
   /// Kill the current session.
   Future killSession({String? sessionError}) async {
     final message = sessionError ?? 'Session disconnected';


### PR DESCRIPTION
@RootSoft - there are some issue I've discovered while trying to implement wallet side of WalletConnect:

- PeerId and PeerMeta correctly returned in approveSession (otherwise dApp will ignore the response)
- PeerId is added to subscriptions when the session approved
- PeerId is added to subscriptions when connector is created with existing session (session restoration)