### PR TITLE
stubs out cosmos_walletconnect_provider

### DIFF
--- a/lib/src/providers/cosmos_walletconnect_provider.dart
+++ b/lib/src/providers/cosmos_walletconnect_provider.dart
@@ -1,0 +1,10 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:convert/convert.dart';
+import 'package:walletconnect_dart/walletconnect_dart.dart';
+
+class CosmosWalletConnectProvider extends WalletConnectProvider {
+  CosmosWalletConnectProvider(WalletConnect connector)
+      : super(connector: connector);
+}

--- a/lib/src/providers/providers.dart
+++ b/lib/src/providers/providers.dart
@@ -1,3 +1,4 @@
 export 'algorand_walletconnect_provider.dart';
+export 'cosmos_walletconnect_provider.dart';
 export 'ethereum_walletconnect_provider.dart';
 export 'wallet_connect_provider.dart';


### PR DESCRIPTION
Aiming to achieve the following in Flutter: [cosmology/cosmos-wallet](https://github.com/cosmology-tech/cosmos-wallet)

Example in TypeScript (Keplr):
https://github.com/cosmology-tech/cosmos-wallet/blob/main/packages/keplr/src/connectors/keplr-walletconnect.ts