### PR TITLE
[fix] killSession not working, #84

### DIFF
--- a/lib/src/walletconnect.dart
+++ b/lib/src/walletconnect.dart
@@ -392,6 +392,8 @@ class WalletConnect {
     );
 
     unawaited(_sendRequest(request));
+    // Avoid starting `_handleSessionDisconnect` before completing `_sendRequest`, which will cause the dapp to not be disconnected from the wallet, https://github.com/RootSoft/walletconnect-dart-sdk/issues/84
+    await Future.delayed(const Duration(milliseconds: 100));
 
     await _handleSessionDisconnect(errorMessage: message, forceClose: true);
   }


### PR DESCRIPTION
fix #84

The problem is caused by the use of `unawaited`, I think it is because the `killSession` request will not have any response and the author wants to run `killSession` and then use `_handleSessionDisconnect` to reset the local state immediately.
Unfortunately, the actual situation is that the local state is reset before the `killSession` request is sent out, so a valid `killSession` request cannot be sent successfully.

```dart
Future killSession({String? sessionError}) async {
   ...
   unawaited(_sendRequest(request));
   await _handleSessionDisconnect(errorMessage: message, forceClose: true);
   ..
}
```

To reduce the impact on other places, I just add a delay to ensure that the `killSession` request can be sent out before the `_handleSessionDisconnect` reset local state.

```dart
unawaited(_sendRequest(request));
// Avoid starting `_handleSessionDisconnect` before completing `_sendRequest`, which will cause the dapp to not be disconnected from the wallet, https://github.com/RootSoft/walletconnect-dart-sdk/issues/84
await Future.delayed(const Duration(milliseconds: 100));
await _handleSessionDisconnect(errorMessage: message, forceClose: true);
```

Hope to approve this PR, please let me know if there are any problems 🙏🏻 Thanks so much
