### PR TITLE
Fix `personal_sign` generates wrong signature

### DIFF
--- a/lib/src/providers/ethereum_walletconnect_provider.dart
+++ b/lib/src/providers/ethereum_walletconnect_provider.dart
@@ -42,11 +42,10 @@ class EthereumWalletConnectProvider extends WalletConnectProvider {
   Future<String> personalSign({
     required String message,
     required String address,
-    required String password,
   }) async {
     final result = await connector.sendCustomRequest(
       method: 'personal_sign',
-      params: [address, message, password],
+      params: [message, address],
     );
 
     return result;

--- a/lib/src/providers/ethereum_walletconnect_provider.dart
+++ b/lib/src/providers/ethereum_walletconnect_provider.dart
@@ -34,9 +34,8 @@ class EthereumWalletConnectProvider extends WalletConnectProvider {
   }
 
   /// Signs method calculates an Ethereum specific signature.
-  /// [address] - 20B address
   /// [message] - message to sign
-  /// [password] - The password of the account to sign data with
+  /// [address] - 20B address
   ///
   /// Returns signature.
   Future<String> personalSign({


### PR DESCRIPTION
According to this [walletconnect protocal doc](https://docs.walletconnect.com/1.0/json-rpc-api-methods/ethereum#personal_sign), correct order of params is `[message, address]` instead of `[address, message]`. And there is no `password` parameter.

This error only occurs in certain wallet app because some apps like MetaMask and ImToken handles the params in both order.

Close #80 

# Changes
fix `personal_sign` params order